### PR TITLE
Add leakage-free SDF/SIREN Geom-DeepONet for micro-step

### DIFF
--- a/.github/workflows/week9-materials.yml
+++ b/.github/workflows/week9-materials.yml
@@ -6,14 +6,17 @@ on:
     paths:
       - ".github/workflows/week9-materials.yml"
       - "flowmllab/mahdavi_deeponet.py"
+      - "flowmllab/step_geom_deeponet.py"
       - "notebooks/week09/make_week9_notebooks.py"
       - "qa/build_step_height_archive.py"
       - "qa/build_step_article_contours.py"
       - "qa/build_step_leakage_free_contours.py"
       - "qa/run_step_height_teaching_validation.py"
+      - "qa/run_step_geom_deeponet.py"
       - "qa/build_week9_mahdavi_deeponet_data.py"
       - "results/mahdavi_deeponet/**"
       - "tests/test_mahdavi_deeponet.py"
+      - "tests/test_step_geom_deeponet.py"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -344,6 +344,33 @@ and
   </a>
 </p>
 
+### Experimental SDF/SIREN Geom-DeepONet
+
+[`flowmllab/step_geom_deeponet.py`](flowmllab/step_geom_deeponet.py) implements
+a two-dimensional adaptation of He et al.'s Geom-DeepONet for this same step
+dataset. Its branch receives only `h/H`; its point trunk receives normalized
+`(x,y)` and an analytic signed distance to the step boundary. Initial
+branch/trunk features are fused, pooled, passed through a SIREN trunk, and
+contracted to predict `(U,V)`. The input builder has no flow-field argument, and
+tests prove that changing target `U,V` cannot change sampled locations or model
+inputs.
+
+Run the complete 5/2/2 development protocol after installing the optional ML
+dependencies:
+
+```bash
+python -m pip install -e ".[ml]"
+python qa/run_step_geom_deeponet.py --root . --epochs 500
+```
+
+The runner selects the zonal-loss weight using H33/H58, refits on all seven
+learning cases, and opens the separate H44/H67 archive only afterward. It is a
+development benchmark until multi-seed accuracy and physics gates are retained;
+it does not replace the checked-in coordinate-MLP evidence. This implementation
+supports variable point counts, but the available data vary only `h/H` at fixed
+`Kn=0.01`, so they do not establish arbitrary-shape or joint `(Kn,h/H)`
+generalization.
+
 [Lab 2](https://colab.research.google.com/github/Ehsan-Roohi/FlowMLLab/blob/main/notebooks/week09/W9_Lab2_Shock_Aligned_Nozzle_DeepONet_Student.ipynb)
 uses a compact, checksummed derivative of all 15 public micro-nozzle DSMC
 snapshots. It directly reproduces the density-POD compression from 8 physical

--- a/flowmllab/__init__.py
+++ b/flowmllab/__init__.py
@@ -14,16 +14,28 @@ from .probabilistic_uq import (
     fit_pod_gaussian_process,
     validate_probabilistic_uq_evidence,
 )
+from .step_geom_deeponet import (
+    StepDomain,
+    build_step_geom_deeponet,
+    infer_step_domain,
+    step_geom_deeponet_inputs,
+    step_signed_distance,
+)
 
 __all__ = [
     "CylinderLBMConfig",
+    "StepDomain",
     "ValidationError",
+    "build_step_geom_deeponet",
     "discover_repository_root",
     "fit_bayesian_linear_regression",
     "fit_pod_gaussian_process",
     "grid_convergence_diagnostics",
+    "infer_step_domain",
     "recommended_parameters",
     "simulate_cylinder",
+    "step_geom_deeponet_inputs",
+    "step_signed_distance",
     "validate_core_assets",
     "validate_probabilistic_uq_evidence",
     "validate_week8_evidence",

--- a/flowmllab/step_geom_deeponet.py
+++ b/flowmllab/step_geom_deeponet.py
@@ -1,0 +1,733 @@
+"""Leakage-free Geom-DeepONet utilities for the rarefied micro-step.
+
+This module adapts the architecture of He et al. (2024) to the two-dimensional
+backward-facing-step data used by FlowMLLab.  The geometry branch receives only
+declared case parameters.  The point trunk receives normalized coordinates and
+an analytic signed-distance value.  No velocity patch, target-derived mask, or
+held-out field can enter either model input.
+
+The implementation retains the distinctive Geom-DeepONet stages: an initial
+branch/trunk encoding, element-wise feature fusion, global pooling, a SIREN
+post-fusion trunk, and a final branch--trunk contraction.  It supports any
+number of query points at inference, although the present dataset establishes
+generalization only over the single geometry parameter ``h/H`` at fixed
+``Kn=0.01``.
+
+Reference
+---------
+J. He et al., "Geom-DeepONet: A point-cloud-based deep operator network for
+field predictions on 3D parameterized geometries," Computer Methods in Applied
+Mechanics and Engineering 429 (2024) 117130.
+https://doi.org/10.1016/j.cma.2024.117130
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+GEOM_DEEPONET_DOI = "10.1016/j.cma.2024.117130"
+
+
+@dataclass(frozen=True)
+class StepDomain:
+    """Physical bounds for one rectangular channel with a backward-facing step."""
+
+    x_min_m: float
+    x_max_m: float
+    y_min_m: float
+    y_max_m: float
+    step_x_m: float = 25.0e-9
+
+    def __post_init__(self) -> None:
+        values = np.asarray(
+            [self.x_min_m, self.x_max_m, self.y_min_m, self.y_max_m, self.step_x_m],
+            dtype=float,
+        )
+        if not np.isfinite(values).all():
+            raise ValueError("step-domain coordinates must be finite")
+        if self.x_max_m <= self.x_min_m or self.y_max_m <= self.y_min_m:
+            raise ValueError("step-domain upper bounds must exceed lower bounds")
+        if not self.x_min_m < self.step_x_m < self.x_max_m:
+            raise ValueError("step_x_m must lie strictly inside the streamwise bounds")
+
+    @property
+    def length_m(self) -> float:
+        return float(self.x_max_m - self.x_min_m)
+
+    @property
+    def height_m(self) -> float:
+        return float(self.y_max_m - self.y_min_m)
+
+    @property
+    def length_over_height(self) -> float:
+        return self.length_m / self.height_m
+
+
+def infer_step_domain(
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+    *,
+    step_x_m: float = 25.0e-9,
+) -> StepDomain:
+    """Infer physical wall locations from a cell-centred Cartesian point cloud.
+
+    The published step coordinates are cell centres.  Using their extrema as
+    wall locations would incorrectly assign zero SDF to the first fluid cells.
+    The half-cell extension below recovers the physical channel bounds while
+    tolerating the small decimal round-off in the exported Tecplot files.
+    """
+
+    x = np.unique(np.asarray(x_m, dtype=float).ravel())
+    y = np.unique(np.asarray(y_m, dtype=float).ravel())
+    if len(x) < 2 or len(y) < 2:
+        raise ValueError("at least two unique x and y cell centres are required")
+    if not np.isfinite(x).all() or not np.isfinite(y).all():
+        raise ValueError("step coordinates must be finite")
+    dx = float(np.median(np.diff(x)))
+    dy = float(np.median(np.diff(y)))
+    if dx <= 0.0 or dy <= 0.0:
+        raise ValueError("step cell-centre coordinates must be strictly increasing")
+    if not np.allclose(np.diff(x), dx, rtol=5.0e-3, atol=0.0):
+        raise ValueError("x coordinates are not a near-uniform cell-centred grid")
+    if not np.allclose(np.diff(y), dy, rtol=5.0e-3, atol=0.0):
+        raise ValueError("y coordinates are not a near-uniform cell-centred grid")
+    return StepDomain(
+        x_min_m=float(x[0] - 0.5 * dx),
+        x_max_m=float(x[-1] + 0.5 * dx),
+        y_min_m=float(y[0] - 0.5 * dy),
+        y_max_m=float(y[-1] + 0.5 * dy),
+        step_x_m=float(step_x_m),
+    )
+
+
+def _distance_to_segment(
+    x: np.ndarray,
+    y: np.ndarray,
+    start: tuple[float, float],
+    end: tuple[float, float],
+) -> np.ndarray:
+    x0, y0 = start
+    dx, dy = end[0] - x0, end[1] - y0
+    denominator = dx * dx + dy * dy
+    projection = np.clip(((x - x0) * dx + (y - y0) * dy) / denominator, 0.0, 1.0)
+    return np.hypot(x - (x0 + projection * dx), y - (y0 + projection * dy))
+
+
+def step_signed_distance(
+    height_ratio: float,
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+    *,
+    domain: StepDomain,
+    normalized: bool = True,
+) -> np.ndarray:
+    """Return the exact polygon SDF for the backward-facing-step fluid domain.
+
+    Positive values are inside the fluid, negative values are inside the solid
+    step or outside the channel, and zero lies on the boundary.  With
+    ``normalized=True`` (the model default), distance is divided by channel
+    height so the Euclidean metric preserves the physical ``L/H`` aspect ratio.
+    """
+
+    h = float(height_ratio)
+    if not 0.0 < h < 1.0:
+        raise ValueError("height_ratio must lie strictly between zero and one")
+    x, y = np.broadcast_arrays(np.asarray(x_m, dtype=float), np.asarray(y_m, dtype=float))
+    if not np.isfinite(x).all() or not np.isfinite(y).all():
+        raise ValueError("SDF query coordinates must be finite")
+
+    x0, x1 = domain.x_min_m, domain.x_max_m
+    y0, y1 = domain.y_min_m, domain.y_max_m
+    xs = domain.step_x_m
+    ys = y0 + h * domain.height_m
+    vertices = (
+        (x0, ys),
+        (xs, ys),
+        (xs, y0),
+        (x1, y0),
+        (x1, y1),
+        (x0, y1),
+    )
+    distances = [
+        _distance_to_segment(x, y, start, end)
+        for start, end in zip(vertices, vertices[1:] + vertices[:1], strict=True)
+    ]
+    distance = np.minimum.reduce(distances)
+    in_box = (x >= x0) & (x <= x1) & (y >= y0) & (y <= y1)
+    in_solid_step = (x < xs) & (y < ys)
+    in_fluid = in_box & ~in_solid_step
+    signed = np.where(in_fluid, distance, -distance)
+    signed = np.where(distance <= 8.0 * np.finfo(float).eps * domain.height_m, 0.0, signed)
+    if normalized:
+        signed = signed / domain.height_m
+    return signed
+
+
+def step_geom_deeponet_inputs(
+    height_ratio: float,
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+    *,
+    domain: StepDomain,
+    dtype: np.dtype[Any] | type = np.float32,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build the only two inputs accepted by the micro-step Geom-DeepONet.
+
+    Returns a one-row geometry branch ``[h/H]`` and a point trunk containing
+    ``[2*x/L-1, 2*y/H-1, SDF/H]``.  The deliberately narrow signature makes it
+    impossible to pass U, V, pressure, a vortex mask, or a target-field patch.
+    """
+
+    h = float(height_ratio)
+    x, y = np.broadcast_arrays(np.asarray(x_m, dtype=float), np.asarray(y_m, dtype=float))
+    x_normalized = 2.0 * (x - domain.x_min_m) / domain.length_m - 1.0
+    y_normalized = 2.0 * (y - domain.y_min_m) / domain.height_m - 1.0
+    sdf = step_signed_distance(h, x, y, domain=domain, normalized=True)
+    branch = np.asarray([[h]], dtype=dtype)
+    trunk = np.column_stack(
+        (x_normalized.ravel(), y_normalized.ravel(), sdf.ravel())
+    ).astype(dtype, copy=False)
+    if not np.isfinite(trunk).all():
+        raise ValueError("Geom-DeepONet trunk features contain NaN or infinity")
+    return branch, trunk
+
+
+@dataclass(frozen=True)
+class StepVelocityScale:
+    """Zero-preserving RMS scales for the two velocity components."""
+
+    u: float
+    v: float
+
+    def __post_init__(self) -> None:
+        scales = np.asarray([self.u, self.v], dtype=float)
+        if not np.isfinite(scales).all() or np.any(scales <= 0.0):
+            raise ValueError("velocity scales must be finite and positive")
+
+    @property
+    def array(self) -> np.ndarray:
+        return np.asarray([self.u, self.v], dtype=float)
+
+    def transform(self, velocity: np.ndarray) -> np.ndarray:
+        values = np.asarray(velocity, dtype=float)
+        if values.shape[-1] != 2:
+            raise ValueError("velocity must have final dimension [U,V]")
+        return values / self.array
+
+    def inverse_transform(self, velocity: np.ndarray) -> np.ndarray:
+        values = np.asarray(velocity, dtype=float)
+        if values.shape[-1] != 2:
+            raise ValueError("velocity must have final dimension [U,V]")
+        return values * self.array
+
+
+def fit_step_velocity_scale(
+    cases: Mapping[int, Mapping[str, np.ndarray]],
+    selected_heights: Sequence[int] | np.ndarray,
+) -> StepVelocityScale:
+    """Fit target scales from explicitly supplied training geometries only."""
+
+    sum_squares = np.zeros(2, dtype=float)
+    count = 0
+    for height in np.asarray(selected_heights, dtype=int):
+        if int(height) not in cases:
+            raise KeyError(f"H{height} is not present in the supplied training store")
+        case = cases[int(height)]
+        velocity = np.column_stack((case["u"], case["v"])).astype(float, copy=False)
+        if not np.isfinite(velocity).all():
+            raise ValueError(f"H{height} contains non-finite velocity targets")
+        sum_squares += np.sum(velocity * velocity, axis=0)
+        count += len(velocity)
+    if count == 0:
+        raise ValueError("selected_heights must contain at least one geometry")
+    rms = np.sqrt(sum_squares / count)
+    return StepVelocityScale(float(rms[0]), float(rms[1]))
+
+
+@dataclass(frozen=True)
+class StepGeomTrainingBatch:
+    """Fixed-size case batches for case-wise Geom-DeepONet training."""
+
+    parameters: np.ndarray
+    trunk: np.ndarray
+    targets: np.ndarray
+    height_percent: np.ndarray
+    point_indices: np.ndarray
+
+
+def sample_step_geom_training_batch(
+    cases: Mapping[int, Mapping[str, np.ndarray]],
+    selected_heights: Sequence[int] | np.ndarray,
+    *,
+    domain: StepDomain,
+    velocity_scale: StepVelocityScale,
+    points_per_case: int = 4096,
+    seed: int = 690,
+) -> StepGeomTrainingBatch:
+    """Uniformly sample complete geometries without target-conditioned inputs.
+
+    Sampling depends only on row count and ``seed``.  U and V are read after
+    indices and model inputs are fixed, solely to construct supervised targets.
+    This means altering target values cannot alter the branch, trunk, or sampled
+    locations.
+    """
+
+    heights = np.asarray(selected_heights, dtype=int).reshape(-1)
+    if len(heights) == 0 or len(np.unique(heights)) != len(heights):
+        raise ValueError("selected_heights must be non-empty and unique")
+    if int(points_per_case) < 1:
+        raise ValueError("points_per_case must be positive")
+    rng = np.random.default_rng(seed)
+    parameters, trunks, targets, indices_by_case = [], [], [], []
+    for height in heights:
+        integer_height = int(height)
+        if integer_height not in cases:
+            raise KeyError(f"H{height} is not present in the supplied training store")
+        case = cases[integer_height]
+        x = np.asarray(case["x"], dtype=float).reshape(-1)
+        y = np.asarray(case["y"], dtype=float).reshape(-1)
+        u = np.asarray(case["u"], dtype=float).reshape(-1)
+        v = np.asarray(case["v"], dtype=float).reshape(-1)
+        if not (len(x) == len(y) == len(u) == len(v)):
+            raise ValueError(f"H{height} has inconsistent point-array lengths")
+        if points_per_case > len(x):
+            raise ValueError(
+                f"H{height} has {len(x)} rows, fewer than points_per_case={points_per_case}"
+            )
+        indices = np.sort(rng.choice(len(x), int(points_per_case), replace=False))
+        branch, trunk = step_geom_deeponet_inputs(
+            integer_height / 100.0,
+            x[indices],
+            y[indices],
+            domain=domain,
+        )
+        parameters.append(branch[0])
+        trunks.append(trunk)
+        physical_targets = np.column_stack((u[indices], v[indices]))
+        targets.append(velocity_scale.transform(physical_targets).astype(np.float32))
+        indices_by_case.append(indices)
+    return StepGeomTrainingBatch(
+        parameters=np.asarray(parameters, dtype=np.float32),
+        trunk=np.asarray(trunks, dtype=np.float32),
+        targets=np.asarray(targets, dtype=np.float32),
+        height_percent=heights.copy(),
+        point_indices=np.asarray(indices_by_case, dtype=int),
+    )
+
+
+def _tensorflow() -> Any:
+    try:
+        import tensorflow as tf
+    except ImportError as error:  # pragma: no cover - exercised without ML extra
+        raise ImportError(
+            "Geom-DeepONet requires the optional ML dependencies: "
+            "python -m pip install 'flowmllab[ml]'"
+        ) from error
+    return tf
+
+
+_KERAS_COMPONENTS: tuple[type[Any], type[Any], type[Any]] | None = None
+
+
+def _keras_components() -> tuple[type[Any], type[Any], type[Any]]:
+    """Create serializable Keras layers lazily so base imports need no TensorFlow."""
+
+    global _KERAS_COMPONENTS
+    if _KERAS_COMPONENTS is not None:
+        return _KERAS_COMPONENTS
+    tf = _tensorflow()
+    keras = tf.keras
+
+    @keras.utils.register_keras_serializable(package="flowmllab")
+    class SirenDense(keras.layers.Layer):
+        def __init__(
+            self,
+            units: int,
+            *,
+            omega_0: float = 10.0,
+            first: bool = False,
+            **kwargs: Any,
+        ) -> None:
+            super().__init__(**kwargs)
+            self.units = int(units)
+            self.omega_0 = float(omega_0)
+            self.first = bool(first)
+
+        def build(self, input_shape: Any) -> None:
+            input_width = int(input_shape[-1])
+            bound = (
+                1.0 / input_width
+                if self.first
+                else np.sqrt(6.0 / input_width) / self.omega_0
+            )
+            initializer = keras.initializers.RandomUniform(-bound, bound)
+            self.kernel = self.add_weight(
+                name="kernel",
+                shape=(input_width, self.units),
+                initializer=initializer,
+                trainable=True,
+            )
+            self.bias = self.add_weight(
+                name="bias",
+                shape=(self.units,),
+                initializer=initializer,
+                trainable=True,
+            )
+            super().build(input_shape)
+
+        def call(self, inputs: Any) -> Any:
+            return tf.sin(self.omega_0 * (tf.linalg.matmul(inputs, self.kernel) + self.bias))
+
+        def get_config(self) -> dict[str, Any]:
+            return {
+                **super().get_config(),
+                "units": self.units,
+                "omega_0": self.omega_0,
+                "first": self.first,
+            }
+
+    @keras.utils.register_keras_serializable(package="flowmllab")
+    class BroadcastMultiply(keras.layers.Layer):
+        def call(self, inputs: Sequence[Any]) -> Any:
+            branch, point_features = inputs
+            return point_features * tf.expand_dims(branch, axis=1)
+
+    @keras.utils.register_keras_serializable(package="flowmllab")
+    class OperatorContraction(keras.layers.Layer):
+        def __init__(self, rank: int, output_dim: int, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.rank = int(rank)
+            self.output_dim = int(output_dim)
+
+        def build(self, input_shape: Any) -> None:
+            self.output_bias = self.add_weight(
+                name="output_bias",
+                shape=(self.output_dim,),
+                initializer="zeros",
+                trainable=True,
+            )
+            super().build(input_shape)
+
+        def call(self, inputs: Sequence[Any]) -> Any:
+            branch, point_features = inputs
+            shape = tf.shape(point_features)
+            trunk = tf.reshape(
+                point_features,
+                (shape[0], shape[1], self.rank, self.output_dim),
+            )
+            return tf.einsum("br,bnro->bno", branch, trunk) + self.output_bias
+
+        def get_config(self) -> dict[str, Any]:
+            return {
+                **super().get_config(),
+                "rank": self.rank,
+                "output_dim": self.output_dim,
+            }
+
+    _KERAS_COMPONENTS = SirenDense, BroadcastMultiply, OperatorContraction
+    return _KERAS_COMPONENTS
+
+
+def build_step_geom_deeponet(
+    *,
+    parameter_dim: int = 1,
+    query_dim: int = 3,
+    output_dim: int = 2,
+    width: int = 48,
+    omega_0: float = 10.0,
+    activation: str = "swish",
+    seed: int = 690,
+) -> Any:
+    """Build the SDF/SIREN Geom-DeepONet used for the step experiment.
+
+    Input shapes are ``(batch, parameter_dim)`` and
+    ``(batch, arbitrary_points, query_dim)``.  For the current micro-step,
+    ``parameter_dim=1`` is ``h/H``, ``query_dim=3`` is ``x, y, SDF``, and the
+    two outputs are U and V.  The architecture is created lazily so importing
+    FlowMLLab does not require TensorFlow.
+    """
+
+    if min(parameter_dim, query_dim, output_dim) < 1:
+        raise ValueError("input and output dimensions must be positive")
+    if width < 4 or omega_0 <= 0.0:
+        raise ValueError("width must be at least four and omega_0 must be positive")
+    tf = _tensorflow()
+    tf.keras.utils.set_random_seed(seed)
+    keras = tf.keras
+    SirenDense, BroadcastMultiply, OperatorContraction = _keras_components()
+
+    parameters = keras.Input(shape=(parameter_dim,), name="geometry_parameters")
+    query = keras.Input(shape=(None, query_dim), name="query_x_y_sdf")
+
+    branch = parameters
+    trunk = query
+    for index, units in enumerate((50, 50, width), start=1):
+        branch = keras.layers.Dense(
+            units, activation=activation, name=f"branch_pre_{index}"
+        )(branch)
+        trunk = keras.layers.Dense(
+            units, activation=activation, name=f"trunk_pre_{index}"
+        )(trunk)
+
+    mixed = BroadcastMultiply(name="intermediate_geometry_fusion")([branch, trunk])
+    pooled = keras.layers.GlobalAveragePooling1D(name="geometry_point_pool")(mixed)
+
+    branch_post = pooled
+    for index, units in enumerate((2 * width, 2 * width, width), start=1):
+        branch_post = keras.layers.Dense(
+            units, activation=activation, name=f"branch_post_{index}"
+        )(branch_post)
+
+    trunk_post = mixed
+    for index, units in enumerate((2 * width, 2 * width, width * output_dim), start=1):
+        trunk_post = SirenDense(
+            units, omega_0=omega_0, name=f"siren_trunk_{index}"
+        )(trunk_post)
+
+    outputs = OperatorContraction(
+        rank=width,
+        output_dim=output_dim,
+        name="branch_trunk_contraction",
+    )([branch_post, trunk_post])
+    return keras.Model(
+        inputs=(parameters, query),
+        outputs=outputs,
+        name="step_geom_deeponet",
+    )
+
+
+def step_zonal_loss(alpha: float | None = None) -> Any:
+    """Return unweighted MSE or a separately normalized reverse-flow loss.
+
+    Because :class:`StepVelocityScale` scales about zero, ``U < 0`` has the
+    same meaning in scaled and physical units.  The target-derived region is
+    used only inside the training loss and never enters either model input.
+    """
+
+    tf = _tensorflow()
+    if alpha is None:
+        return tf.keras.losses.MeanSquaredError(name="velocity_mse")
+    value = float(alpha)
+    if not 0.0 < value < 1.0:
+        raise ValueError("alpha must lie strictly between zero and one")
+
+    def loss(y_true: Any, y_prediction: Any) -> Any:
+        squared = tf.reduce_sum(tf.square(y_prediction - y_true), axis=-1)
+        vortex = y_true[..., 0] < 0.0
+        main = ~vortex
+        vortex_count = tf.reduce_sum(tf.cast(vortex, squared.dtype))
+        main_count = tf.reduce_sum(tf.cast(main, squared.dtype))
+        vortex_mean = tf.math.divide_no_nan(
+            tf.reduce_sum(tf.where(vortex, squared, tf.zeros_like(squared))),
+            vortex_count,
+        )
+        main_mean = tf.math.divide_no_nan(
+            tf.reduce_sum(tf.where(main, squared, tf.zeros_like(squared))),
+            main_count,
+        )
+        vortex_weight = value * tf.cast(vortex_count > 0.0, squared.dtype)
+        main_weight = (1.0 - value) * tf.cast(main_count > 0.0, squared.dtype)
+        return tf.math.divide_no_nan(
+            vortex_weight * vortex_mean + main_weight * main_mean,
+            vortex_weight + main_weight,
+        )
+
+    loss.__name__ = f"zonal_velocity_alpha_{value:.2f}"
+    return loss
+
+
+@dataclass
+class StepGeomDeepONetFit:
+    """Fitted model plus the preprocessing contract needed for inference."""
+
+    model: Any
+    domain: StepDomain
+    velocity_scale: StepVelocityScale
+    training_heights: tuple[int, ...]
+    history: dict[str, list[float]]
+    configuration: dict[str, Any]
+
+
+def fit_step_geom_deeponet(
+    cases: Mapping[int, Mapping[str, np.ndarray]],
+    selected_heights: Sequence[int] | np.ndarray,
+    *,
+    domain: StepDomain | None = None,
+    validation_heights: Sequence[int] | np.ndarray | None = None,
+    points_per_case: int = 4096,
+    alpha: float | None = 0.6,
+    width: int = 48,
+    omega_0: float = 10.0,
+    learning_rate: float = 8.0e-4,
+    epochs: int = 500,
+    batch_size: int = 1,
+    seed: int = 690,
+    verbose: int = 0,
+    callbacks: Sequence[Any] | None = None,
+) -> StepGeomDeepONetFit:
+    """Fit one leakage-free case-wise micro-step Geom-DeepONet.
+
+    Pass only the learning archive.  ``selected_heights`` and optional
+    ``validation_heights`` are looked up in that supplied mapping, so a sealed
+    geometry cannot be accessed accidentally.  Hyperparameter selection and a
+    final seven-case refit should happen before loading the separate test file.
+    """
+
+    heights = np.asarray(selected_heights, dtype=int).reshape(-1)
+    if len(heights) == 0:
+        raise ValueError("selected_heights must contain at least one geometry")
+    if epochs < 1 or batch_size < 1 or learning_rate <= 0.0:
+        raise ValueError("epochs, batch_size, and learning_rate must be positive")
+    first_height = int(heights[0])
+    if first_height not in cases:
+        raise KeyError(f"H{first_height} is not present in the supplied training store")
+    if domain is None:
+        first = cases[first_height]
+        domain = infer_step_domain(first["x"], first["y"])
+    scale = fit_step_velocity_scale(cases, heights)
+    training = sample_step_geom_training_batch(
+        cases,
+        heights,
+        domain=domain,
+        velocity_scale=scale,
+        points_per_case=points_per_case,
+        seed=seed,
+    )
+
+    validation_data = None
+    validation_tuple: tuple[int, ...] = ()
+    if validation_heights is not None:
+        validation_array = np.asarray(validation_heights, dtype=int).reshape(-1)
+        validation_tuple = tuple(int(value) for value in validation_array)
+        validation = sample_step_geom_training_batch(
+            cases,
+            validation_array,
+            domain=domain,
+            velocity_scale=scale,
+            points_per_case=points_per_case,
+            seed=seed + 1,
+        )
+        validation_data = (
+            (validation.parameters, validation.trunk),
+            validation.targets,
+        )
+
+    tf = _tensorflow()
+    model = build_step_geom_deeponet(
+        width=width,
+        omega_0=omega_0,
+        seed=seed,
+    )
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(learning_rate=float(learning_rate)),
+        loss=step_zonal_loss(alpha),
+    )
+    fitted_history = model.fit(
+        (training.parameters, training.trunk),
+        training.targets,
+        validation_data=validation_data,
+        epochs=int(epochs),
+        batch_size=int(batch_size),
+        shuffle=True,
+        verbose=int(verbose),
+        callbacks=list(callbacks or ()),
+    )
+    return StepGeomDeepONetFit(
+        model=model,
+        domain=domain,
+        velocity_scale=scale,
+        training_heights=tuple(int(value) for value in heights),
+        history={
+            key: [float(item) for item in values]
+            for key, values in fitted_history.history.items()
+        },
+        configuration={
+            "points_per_case": int(points_per_case),
+            "validation_heights": validation_tuple,
+            "alpha": None if alpha is None else float(alpha),
+            "width": int(width),
+            "omega_0": float(omega_0),
+            "learning_rate": float(learning_rate),
+            "epochs": int(epochs),
+            "batch_size": int(batch_size),
+            "seed": int(seed),
+        },
+    )
+
+
+def predict_step_geom_deeponet(
+    fitted: StepGeomDeepONetFit,
+    height_percent: int,
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+) -> np.ndarray:
+    """Predict physical U,V using geometry and coordinates only."""
+
+    branch, trunk = step_geom_deeponet_inputs(
+        float(height_percent) / 100.0,
+        x_m,
+        y_m,
+        domain=fitted.domain,
+    )
+    scaled = np.asarray(
+        fitted.model((branch, trunk[None, ...]), training=False), dtype=float
+    )[0]
+    return fitted.velocity_scale.inverse_transform(scaled)
+
+
+def evaluate_step_geom_deeponet(
+    fitted: StepGeomDeepONetFit,
+    cases: Mapping[int, Mapping[str, np.ndarray]],
+    selected_heights: Sequence[int] | np.ndarray,
+) -> list[dict[str, float | int]]:
+    """Evaluate explicitly supplied cases without using targets as inputs."""
+
+    from .mahdavi_deeponet import zonal_velocity_metrics
+
+    rows: list[dict[str, float | int]] = []
+    metric_alpha = 0.5 if fitted.configuration["alpha"] is None else float(
+        fitted.configuration["alpha"]
+    )
+    for height in np.asarray(selected_heights, dtype=int):
+        integer_height = int(height)
+        if integer_height not in cases:
+            raise KeyError(f"H{height} is not present in the supplied evaluation store")
+        case = cases[integer_height]
+        prediction = predict_step_geom_deeponet(
+            fitted,
+            integer_height,
+            case["x"],
+            case["y"],
+        )
+        metrics = zonal_velocity_metrics(
+            case["u"],
+            case["v"],
+            prediction[:, 0],
+            prediction[:, 1],
+            alpha=metric_alpha,
+        )
+        rows.append({"height_percent": integer_height, **metrics})
+    return rows
+
+
+__all__ = [
+    "GEOM_DEEPONET_DOI",
+    "StepDomain",
+    "StepGeomDeepONetFit",
+    "StepGeomTrainingBatch",
+    "StepVelocityScale",
+    "build_step_geom_deeponet",
+    "evaluate_step_geom_deeponet",
+    "fit_step_geom_deeponet",
+    "fit_step_velocity_scale",
+    "infer_step_domain",
+    "predict_step_geom_deeponet",
+    "sample_step_geom_training_batch",
+    "step_geom_deeponet_inputs",
+    "step_signed_distance",
+    "step_zonal_loss",
+]

--- a/qa/run_step_geom_deeponet.py
+++ b/qa/run_step_geom_deeponet.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Train and evaluate the leakage-free micro-step Geom-DeepONet.
+
+The program enforces the existing FlowMLLab 5/2/2 geometry protocol.  It opens
+only the seven-case learning archive for development, selects the zonal weight
+on H33/H58, refits frozen models on all seven permitted cases, and only then
+opens the physically separate H44/H67 test archive.
+
+This is a development benchmark.  It does not overwrite retained release
+evidence unless an explicit output directory is supplied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from flowmllab.mahdavi_deeponet import (
+    STEP_HEIGHT_DEVELOPMENT_PERCENT,
+    STEP_HEIGHT_HELD_OUT_PERCENT,
+    STEP_HEIGHT_VALIDATION_PERCENT,
+    STEP_SOURCE_COMMIT,
+    load_step_height_archive,
+)
+from flowmllab.step_geom_deeponet import (
+    GEOM_DEEPONET_DOI,
+    evaluate_step_geom_deeponet,
+    fit_step_geom_deeponet,
+    infer_step_domain,
+)
+
+
+def mean_percent(rows: list[dict[str, float | int]], key: str) -> float:
+    return 100.0 * float(np.mean([float(row[key]) for row in rows]))
+
+
+def serializable_rows(rows: list[dict[str, float | int]]) -> list[dict[str, Any]]:
+    return [
+        {
+            key: int(value) if isinstance(value, (int, np.integer)) else float(value)
+            for key, value in row.items()
+        }
+        for row in rows
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--epochs", type=int, default=500)
+    parser.add_argument("--points-per-case", type=int, default=4096)
+    parser.add_argument("--width", type=int, default=48)
+    parser.add_argument("--omega-0", type=float, default=10.0)
+    parser.add_argument("--learning-rate", type=float, default=8.0e-4)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=690)
+    parser.add_argument("--alphas", type=float, nargs="+", default=[0.5, 0.6, 0.7, 0.8])
+    parser.add_argument("--global-guard-percent", type=float, default=2.0)
+    parser.add_argument("--verbose", type=int, choices=(0, 1, 2), default=1)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="optional directory for JSON report and final zonal weights",
+    )
+    args = parser.parse_args()
+    if len(set(args.alphas)) != len(args.alphas):
+        raise ValueError("--alphas must be unique")
+    if any(not 0.0 < alpha < 1.0 for alpha in args.alphas):
+        raise ValueError("every --alphas value must lie strictly between zero and one")
+
+    import tensorflow as tf
+
+    def clear_finished_model() -> None:
+        tf.keras.backend.clear_session()
+        gc.collect()
+
+    root = args.root.resolve()
+    start = time.perf_counter()
+
+    # Selection phase: the separate H44/H67 archive is not touched here.
+    learning_cases = load_step_height_archive(root, split="learning")
+    first = learning_cases[int(STEP_HEIGHT_DEVELOPMENT_PERCENT[0])]
+    domain = infer_step_domain(first["x"], first["y"])
+    fit_options = {
+        "domain": domain,
+        "points_per_case": args.points_per_case,
+        "width": args.width,
+        "omega_0": args.omega_0,
+        "learning_rate": args.learning_rate,
+        "epochs": args.epochs,
+        "batch_size": args.batch_size,
+        "seed": args.seed,
+        "verbose": args.verbose,
+    }
+
+    baseline = fit_step_geom_deeponet(
+        learning_cases,
+        STEP_HEIGHT_DEVELOPMENT_PERCENT,
+        alpha=None,
+        **fit_options,
+    )
+    baseline_validation = evaluate_step_geom_deeponet(
+        baseline,
+        learning_cases,
+        STEP_HEIGHT_VALIDATION_PERCENT,
+    )
+    baseline_global = mean_percent(baseline_validation, "full_relative_l2")
+    selection: list[dict[str, Any]] = [
+        {
+            "model": "unweighted",
+            "alpha": None,
+            "validation_global_relative_l2_percent": baseline_global,
+            "validation_vortex_relative_l2_percent": mean_percent(
+                baseline_validation, "vortex_relative_l2"
+            ),
+            "eligible_global_guard": True,
+            "selected": False,
+        }
+    ]
+    del baseline
+    clear_finished_model()
+
+    for alpha in args.alphas:
+        fitted = fit_step_geom_deeponet(
+            learning_cases,
+            STEP_HEIGHT_DEVELOPMENT_PERCENT,
+            alpha=float(alpha),
+            **fit_options,
+        )
+        rows = evaluate_step_geom_deeponet(
+            fitted,
+            learning_cases,
+            STEP_HEIGHT_VALIDATION_PERCENT,
+        )
+        global_error = mean_percent(rows, "full_relative_l2")
+        selection.append(
+            {
+                "model": "zonal",
+                "alpha": float(alpha),
+                "validation_global_relative_l2_percent": global_error,
+                "validation_vortex_relative_l2_percent": mean_percent(
+                    rows, "vortex_relative_l2"
+                ),
+                "eligible_global_guard": global_error
+                <= baseline_global + args.global_guard_percent,
+                "selected": False,
+            }
+        )
+        del fitted
+        clear_finished_model()
+
+    eligible = [
+        row for row in selection[1:] if bool(row["eligible_global_guard"])
+    ]
+    if not eligible:
+        raise RuntimeError("no zonal model satisfies the predeclared global-error guard")
+    winner = min(
+        eligible,
+        key=lambda row: float(row["validation_vortex_relative_l2_percent"]),
+    )
+    selected_alpha = float(winner["alpha"])
+    winner["selected"] = True
+
+    # Freeze architecture, optimization budget, and alpha; refit on all seven cases.
+    final_heights = np.concatenate(
+        (STEP_HEIGHT_DEVELOPMENT_PERCENT, STEP_HEIGHT_VALIDATION_PERCENT)
+    )
+    clear_finished_model()
+    final_unweighted = fit_step_geom_deeponet(
+        learning_cases,
+        final_heights,
+        alpha=None,
+        **fit_options,
+    )
+    final_zonal = fit_step_geom_deeponet(
+        learning_cases,
+        final_heights,
+        alpha=selected_alpha,
+        **fit_options,
+    )
+
+    # This is the first access to the physically separate sealed-test file.
+    test_cases = load_step_height_archive(root, split="test")
+    test_metrics = {
+        "unweighted": serializable_rows(
+            evaluate_step_geom_deeponet(
+                final_unweighted,
+                test_cases,
+                STEP_HEIGHT_HELD_OUT_PERCENT,
+            )
+        ),
+        f"zonal_alpha_{selected_alpha:.2f}": serializable_rows(
+            evaluate_step_geom_deeponet(
+                final_zonal,
+                test_cases,
+                STEP_HEIGHT_HELD_OUT_PERCENT,
+            )
+        ),
+    }
+
+    report = {
+        "status": "development benchmark; not retained release evidence",
+        "source_commit": STEP_SOURCE_COMMIT,
+        "reference_doi": GEOM_DEEPONET_DOI,
+        "split": {
+            "development_percent": STEP_HEIGHT_DEVELOPMENT_PERCENT.tolist(),
+            "validation_percent": STEP_HEIGHT_VALIDATION_PERCENT.tolist(),
+            "held_out_test_percent": STEP_HEIGHT_HELD_OUT_PERCENT.tolist(),
+        },
+        "file_level_test_isolation": True,
+        "test_archive_opened_after_selection_and_final_fit": True,
+        "test_used_for_selection": False,
+        "allowed_model_inputs": [
+            "geometry branch: h/H",
+            "point trunk: normalized x, normalized y, analytic SDF/H",
+        ],
+        "forbidden_model_inputs": [
+            "U or V patch",
+            "target-derived mask",
+            "held-out flow field",
+        ],
+        "domain": asdict(domain),
+        "architecture": {
+            "kind": "2-D Geom-DeepONet adaptation",
+            "intermediate_branch_trunk_fusion": True,
+            "global_point_pooling": "mean",
+            "post_fusion_trunk": "SIREN",
+            "output_fields": ["U", "V"],
+            **final_zonal.configuration,
+        },
+        "selection_rule": (
+            "Minimize mean validation vortex relative L2 among candidates whose "
+            f"mean validation global relative L2 is at most {args.global_guard_percent:g} "
+            "percentage points above the unweighted baseline."
+        ),
+        "selection": selection,
+        "selected_alpha": selected_alpha,
+        "test_metrics": test_metrics,
+        "software": {"numpy": np.__version__, "tensorflow": tf.__version__},
+        "elapsed_seconds": time.perf_counter() - start,
+    }
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_dir is not None:
+        output = args.output_dir.expanduser().resolve()
+        output.mkdir(parents=True, exist_ok=True)
+        report_path = output / "step_geom_deeponet_report.json"
+        weights_path = output / "step_geom_deeponet_zonal.weights.h5"
+        report_path.write_text(rendered, encoding="utf-8")
+        final_zonal.model.save_weights(weights_path)
+        print(f"report: {report_path}")
+        print(f"weights: {weights_path}")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/references/README.md
+++ b/references/README.md
@@ -43,6 +43,7 @@ spatial nodes or shifted physical regimes.
 - **Raissi, Perdikaris & Karniadakis (2019), PINNs.** Foundational formulation for incorporating PDE residuals into neural training. [DOI](https://doi.org/10.1016/j.jcp.2018.10.045)
 - **Karniadakis et al. (2021), Physics-informed machine learning.** Review of data–physics integration, uncertainty, and hybrid modeling. [DOI](https://doi.org/10.1038/s42254-021-00314-5)
 - **Lu et al. (2021), DeepONet.** Branch/trunk operator-learning formulation used in Week 4. [DOI](https://doi.org/10.1038/s42256-021-00302-5)
+- **He et al. (2024), Geom-DeepONet.** Parameterized-geometry branch, coordinate/SDF trunk, SIREN encoding, and intermediate fusion adapted by the experimental Week-9 micro-step implementation. [DOI](https://doi.org/10.1016/j.cma.2024.117130) · [Code](https://github.com/ncsa/GeomDeepONet)
 - **Li et al. (2021), Fourier Neural Operator.** Spectral operator-learning alternative and useful comparison with coordinate networks. [Paper](https://openreview.net/forum?id=c8P9NQVtmnO)
 - **Cai et al. (2021), PINNs for fluid mechanics.** Fluid-specific review and examples. [DOI](https://doi.org/10.1007/s10409-021-01148-1)
 

--- a/results/mahdavi_deeponet/README.md
+++ b/results/mahdavi_deeponet/README.md
@@ -95,6 +95,19 @@ Reproduce the teaching selection and held-out metrics with:
 python qa/run_step_height_teaching_validation.py --root .
 ```
 
+An experimental SDF/SIREN Geom-DeepONet is available separately from the
+retained coordinate-MLP evidence. Install `.[ml]` and run:
+
+```bash
+python qa/run_step_geom_deeponet.py --root . --epochs 500 \
+  --output-dir /path/to/development-run
+```
+
+The output is intentionally labelled development evidence. Promote it to this
+directory's retained evidence only after a predeclared multi-seed comparison,
+the existing full-field/reverse-flow gates, and physical diagnostics have all
+passed.
+
 Rebuild the article-evidence and leakage-free contour sets with:
 
 ```bash

--- a/tests/test_step_geom_deeponet.py
+++ b/tests/test_step_geom_deeponet.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from flowmllab.mahdavi_deeponet import load_step_height_archive
+from flowmllab.step_geom_deeponet import (
+    GEOM_DEEPONET_DOI,
+    StepDomain,
+    build_step_geom_deeponet,
+    fit_step_velocity_scale,
+    infer_step_domain,
+    sample_step_geom_training_batch,
+    step_geom_deeponet_inputs,
+    step_signed_distance,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class StepGeomDeepONetTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.learning = load_step_height_archive(ROOT, split="learning")
+        first = cls.learning[16]
+        cls.domain = infer_step_domain(first["x"], first["y"])
+
+    def test_reference_and_inferred_physical_domain(self) -> None:
+        self.assertEqual(GEOM_DEEPONET_DOI, "10.1016/j.cma.2024.117130")
+        self.assertAlmostEqual(self.domain.x_min_m, 0.0, delta=2.0e-12)
+        self.assertAlmostEqual(self.domain.y_min_m, 0.0, delta=2.0e-12)
+        self.assertAlmostEqual(self.domain.length_over_height, 5.0, delta=0.02)
+        self.assertAlmostEqual(self.domain.step_x_m, 25.0e-9)
+
+    def test_signed_distance_has_exact_step_sign_convention(self) -> None:
+        domain = StepDomain(0.0, 5.0, 0.0, 1.0, step_x_m=1.0)
+        x = np.array([0.5, 2.0, 0.5, 0.5, 1.0, 2.0])
+        y = np.array([0.7, 0.1, 0.2, 0.4, 0.2, 0.0])
+        sdf = step_signed_distance(0.4, x, y, domain=domain)
+        self.assertGreater(sdf[0], 0.0)
+        self.assertAlmostEqual(sdf[1], 0.1)
+        self.assertAlmostEqual(sdf[2], -0.2)
+        np.testing.assert_allclose(sdf[3:], 0.0, atol=1.0e-14)
+
+    def test_geom_inputs_are_only_parameter_coordinates_and_sdf(self) -> None:
+        x = np.array([5.0e-9, 35.0e-9, 70.0e-9])
+        y = np.array([12.0e-9, 4.0e-9, 8.0e-9])
+        branch, trunk = step_geom_deeponet_inputs(
+            0.44, x, y, domain=self.domain
+        )
+        self.assertEqual(branch.shape, (1, 1))
+        self.assertEqual(trunk.shape, (3, 3))
+        self.assertEqual(float(branch[0, 0]), np.float32(0.44))
+        np.testing.assert_allclose(
+            trunk[:, 2],
+            step_signed_distance(0.44, x, y, domain=self.domain),
+            rtol=2.0e-7,
+        )
+
+    def test_target_changes_cannot_change_inputs_or_sample_locations(self) -> None:
+        cases = {height: dict(case) for height, case in self.learning.items()}
+        scale = fit_step_velocity_scale(cases, [16, 21])
+        original = sample_step_geom_training_batch(
+            cases,
+            [16, 21],
+            domain=self.domain,
+            velocity_scale=scale,
+            points_per_case=128,
+            seed=17,
+        )
+        corrupted = {height: dict(case) for height, case in cases.items()}
+        for height in (16, 21):
+            corrupted[height]["u"] = -3.0 * np.asarray(corrupted[height]["u"])
+            corrupted[height]["v"] = 7.0 + np.asarray(corrupted[height]["v"])
+        changed = sample_step_geom_training_batch(
+            corrupted,
+            [16, 21],
+            domain=self.domain,
+            velocity_scale=scale,
+            points_per_case=128,
+            seed=17,
+        )
+        np.testing.assert_array_equal(original.point_indices, changed.point_indices)
+        np.testing.assert_array_equal(original.parameters, changed.parameters)
+        np.testing.assert_array_equal(original.trunk, changed.trunk)
+        self.assertFalse(np.array_equal(original.targets, changed.targets))
+
+    def test_training_store_cannot_supply_a_sealed_geometry(self) -> None:
+        scale = fit_step_velocity_scale(self.learning, [16])
+        with self.assertRaises(KeyError):
+            sample_step_geom_training_batch(
+                self.learning,
+                [44],
+                domain=self.domain,
+                velocity_scale=scale,
+                points_per_case=16,
+            )
+
+    def test_height_changes_sdf_at_fixed_query_point(self) -> None:
+        x = np.array([10.0e-9])
+        y = np.array([10.0e-9])
+        low = step_signed_distance(0.25, x, y, domain=self.domain)
+        high = step_signed_distance(0.67, x, y, domain=self.domain)
+        self.assertGreater(float(low[0]), 0.0)
+        self.assertLess(float(high[0]), 0.0)
+
+    def test_model_accepts_arbitrary_point_counts_when_ml_extra_exists(self) -> None:
+        try:
+            model = build_step_geom_deeponet(width=8, seed=4)
+        except ImportError:
+            self.skipTest("optional TensorFlow dependency is not installed")
+        branch = np.array([[0.44]], dtype=np.float32)
+        for count in (7, 19):
+            trunk = np.zeros((1, count, 3), dtype=np.float32)
+            prediction = np.asarray(model((branch, trunk), training=False))
+            self.assertEqual(prediction.shape, (1, count, 2))
+            self.assertTrue(np.isfinite(prediction).all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a 2-D adaptation of He et al.'s Geom-DeepONet for the variable-height rarefied micro-step
- feed only `h/H` to the geometry branch and normalized `(x, y, SDF/H)` to the point trunk
- retain intermediate branch/trunk fusion, mean point pooling, a post-fusion SIREN trunk, and a two-field `(U,V)` contraction
- infer the physical walls from the cell-centred grid before evaluating the exact backward-facing-step SDF
- add zero-preserving velocity scaling and a separately normalized reverse-flow/main-flow loss
- add a reproducible 5/2/2 runner: H16/H21/H25/H50/H75 development, H33/H58 selection, and H44/H67 sealed test

## Leakage closed

The pinned article repository constructs the test-time patch directly from held-out `U,V` and supplies that patch to the model ([source lines 365–408](https://github.com/Ehsan-Roohi/roohi-step-dnn-mahdavi/blob/c3f211376b42b8dc30daad380eaef5e0ab800b5c/src/height_data_limit_study.py#L365-L408)). It also makes train/validation partitions by shuffling points within the same geometries ([source lines 573–579](https://github.com/Ehsan-Roohi/roohi-step-dnn-mahdavi/blob/c3f211376b42b8dc30daad380eaef5e0ab800b5c/src/height_data_limit_study.py#L573-L579)).

This PR's model-input function has no flow-field argument. A regression test mutates every sampled target `U,V` value and proves that branch features, trunk features, and sampled point indices remain unchanged. The target-derived `U<0` region remains confined to the training loss and evaluation metrics.

## Validation

- `python -m unittest discover -s tests -v`: 78 passed, 3 optional-dependency/data skips
- TensorFlow 2.21 optional test: all 7 Geom-DeepONet tests passed, including variable point counts
- two-epoch real-data fit: loss decreased, validation executed, and physical `(U,V)` inference was finite
- end-to-end one-epoch protocol smoke: alpha selection, seven-case refit, and delayed H44/H67 access completed
- `python -m flowmllab.cli qa --root .`: `FLOWMLLAB_RELEASE_QA_PASS`
- Ruff: all changed Python files pass

The one/two-epoch runs are software smoke tests, not accuracy evidence, and are not checked in.

## Scientific boundary

This supports arbitrary query-point counts and parameterized geometry, but the present nine cases vary only `h/H` at fixed `Kn=0.01`. The PR therefore makes no arbitrary-shape or joint `(Kn,h/H)` generalization claim. Retained accuracy evidence should be added only after the documented multi-seed development run and physics gates.