### PR TITLE
Record recovered cylinder checkpoints and replay-scaler blocker

### DIFF
--- a/qa/CYLINDER_SOURCE_RECOVERY.json
+++ b/qa/CYLINDER_SOURCE_RECOVERY.json
@@ -1,0 +1,46 @@
+{
+  "schema": 1,
+  "inspection_date": "2026-09-06",
+  "method": "read-only Unity shell; sha256sum and h5py metadata, no model deserialization",
+  "source_directory": "/project/pi_roohie_umass_edu/AllMachNNCylinder",
+  "paper_identity_verified": false,
+  "inference_executed": false,
+  "source_sha256": {
+    "32fusion.py": "657644e9d1391ef1523278d066225902876a9d8e610e91f0e16634bb446e2349",
+    "33fusion.py": "a2015510a33bcd7e0dca4e9f2cf16f03b700ab59fe49fa5e1da1d0e2a35778ed"
+  },
+  "checkpoint_sha256": {
+    "modelsold/cylinder_fusion_model_0.h5": "dfbe3d67625ec5908da52b7813583c396959955559de1b888c177ec6edc3b59c",
+    "modelsold/cylinder_fusion_model_1.h5": "59498a8bb5983260af566b416fac40ca40ca074acef0c0ee26d0a6dbfdc21842",
+    "modelsold/cylinder_fusion_model_2.h5": "97c83e6c3da75842962179f848fa2b993ba7ea7928cf53b0616ad99773731748",
+    "modelsold/cylinder_fusion_model_3.h5": "1ae32784e0f83c11046df66847931a519c15b4f56dac9a839c7bc59735425b91",
+    "modelsold/cylinder_fusion_model_4.h5": "14bdbceec025038b4ac1d9d4264ab86441a3dcdc8cf5de876993f4e5eb64e5f8"
+  },
+  "member0_metadata": {
+    "keras_version": "2.15.0",
+    "input_layers": 2,
+    "dense_256_tanh_layers": 8,
+    "add_layers": 4,
+    "lambda_layers": 1,
+    "output_units": 3,
+    "output_activation": "linear"
+  },
+  "scaler_filename_search": {
+    "scope": "recursive source_directory",
+    "patterns": [
+      "*scaler*",
+      "*.pkl",
+      "*.joblib"
+    ],
+    "matches": [],
+    "absence_of_embedded_scalers_proven": false
+  },
+  "blockers": [
+    "Exact producing script and figure association unknown",
+    "Candidate scripts use Mach 5/7/9 training and Mach 10 test, not claimed Mach-15 protocol",
+    "Candidate 33fusion.py refits scalers with a different sample budget during replay",
+    "Original sampling/scalers and model member consistency still need verification"
+  ],
+  "all_five_ordered_layer_classes_and_widths_match": true,
+  "full_topology_equivalence_verified": false
+}

--- a/qa/CYLINDER_SOURCE_RECOVERY.md
+++ b/qa/CYLINDER_SOURCE_RECOVERY.md
@@ -1,0 +1,43 @@
+# Cylinder source recovery — 2026-09-06
+
+The original working directory was located on Unity. Five candidate ensemble
+members exist under `modelsold/cylinder_fusion_model_0.h5` through `_4.h5`.
+Their SHA-256 hashes and the observed source identity are recorded in
+[the recovery record](CYLINDER_SOURCE_RECOVERY.json). These are candidate
+weights, not yet authenticated as the published figure-producing ensemble.
+No original file was changed, no training or inference was launched.
+
+## Verified observations
+
+- `models/` has member 0 and best-checkpoint variants for members 0/1, but lacks
+  the complete set of five identically named ensemble members. `modelsold/`
+  contains all five.
+- Member 0 HDF5 metadata, inspected without TensorFlow deserialization, records
+  Keras 2.15.0, two inputs, eight 256-unit tanh dense layers, four Add layers,
+  one Lambda layer and a three-unit linear output. All five members have the same ordered layer classes and dense widths.
+  Full configurations have different hashes; topology and Lambda semantics
+  remain unchecked. This does not prove a match to a paper figure.
+- Both `32fusion.py` and `33fusion.py` name Mach 5/7/9 as training and Mach 10
+  as test. Both reference the same checkpoint basename. Filename matching is
+  therefore insufficient to identify the producing revision.
+- In `33fusion.py`, training uses `N_f=50000` per file (lines 181–194, 340),
+  whereas replay rebuilds scalers with `N_f=200000` (lines 241–248). Sampling
+  uses `min(N_f, len(df))`, seed 42, before invalid-target filtering (107–125).
+  When the sampled rows differ, refitting can alter the input transform and
+  inverse output transform for unchanged weights. Numerical impact is unmeasured.
+- Recursive filename search found no `*scaler*`, `.pkl` or `.joblib` files.
+  This is not proof that scalers cannot be embedded elsewhere or reconstructed.
+
+## Next executable gate
+
+Recover the exact training data list and sampling configuration for these
+weights; compare all five stored architecture configurations. Reconstruct the
+training scalers only from that identified configuration, persist their numeric
+parameters, and compare against historical exported predictions before scoring
+Mach 15. Do not substitute the replay's larger-sample scalers or start the old
+script directly: its incomplete-ensemble path can trigger fresh training.
+
+The source-directory discovery advances the [paper parity audit](WEEK71_PAPER_PARITY.md).
+It does not close quantitative reproduction. The user-reported asymmetric
+near-cylinder shock overlay belongs to a separate ShockVortexML diagnostic;
+these DSMC surrogate files cannot explain that image by themselves.

--- a/qa/REMAINING_EVIDENCE.md
+++ b/qa/REMAINING_EVIDENCE.md
@@ -8,3 +8,5 @@
 - Week7.1 Mach-cylinder text comparison: completed in [paper-to-course audit](WEEK71_PAPER_PARITY.md), including architecture inconsistencies, split/support differences and retained baseline comparisons. Quantitative figure reproduction remains open pending checkpoints, preprocessing and figure-specific splits; Knudsen/diatomic branches remain unassessed.
 - Micro-step corrigendum, coauthor permission and Week11 preprint: require author decisions; no consent or publication decision inferred.
 - Fresh DSMC test cases: require defined cases and new simulation outputs; the new Re115 case is LBM, not DSMC.
+
+- Cylinder source recovery: [five candidate weights located and hashed on Unity](CYLINDER_SOURCE_RECOVERY.md); member-0 architecture inspected. Producing-script identity and scaler consistency remain blocking; no paper inference claimed.


### PR DESCRIPTION
Located the original AllMachNNCylinder working directory on Unity and five candidate Fusion ensemble members. Record source/checkpoint hashes and read-only HDF5 inspection results.

The candidate scripts use Mach 5/7/9 training and Mach 10 testing; their checkpoint filenames alone cannot authenticate the paper ensemble. In 33fusion.py, training fits scalers on a 50,000-per-file sample while replay refits them using 200,000. The numerical effect is unmeasured and the exact producer is still unknown. No separate scaler files matched the recursive filename search.

Validation: SHA-256 computed on Unity for both scripts and five weights; all five ordered layer-class/width lists compared; member-0 activation and Keras metadata inspected without deserialization. Documentation/JSON only; no model or data changes, inference, or new jobs. Preserve quantitative reproduction as open.